### PR TITLE
#89 Fixed misspelled configuration property

### DIFF
--- a/msgraph-connector-test/src_test/com/microsoft/auth/TestOAuth2Feature.java
+++ b/msgraph-connector-test/src_test/com/microsoft/auth/TestOAuth2Feature.java
@@ -90,7 +90,7 @@ public class TestOAuth2Feature {
     Map<String, Object> props = Map.of(
       "AUTH.appId", "1234",
       "AUTH.secretKey", "5678",
-      "AUTH.userPassFlow", Boolean.TRUE.toString(),
+      "AUTH.useUserPassFlow", Boolean.TRUE.toString(),
       "AUTH.user", "rew",
       "AUTH.password", "notMySecret");
     var payload = toPayload(props);

--- a/msgraph-oauth-feature/src/com/microsoft/auth/OAuth2Feature.java
+++ b/msgraph-oauth-feature/src/com/microsoft/auth/OAuth2Feature.java
@@ -46,7 +46,7 @@ public class OAuth2Feature implements Feature{
     String SCOPE = "AUTH.scope";
     String AUTH_BASE_URI = "AUTH.baseUri";
     String USE_APP_PERMISSIONS = "AUTH.useAppPermissions";
-    String USE_USER_PASS_FLOW = "AUTH.userPassFlow";
+    String USE_USER_PASS_FLOW = "AUTH.useUserPassFlow";
 
     String USER = "AUTH.user";
     String PASS = "AUTH.password";


### PR DESCRIPTION
#89 Fixed the misspelling in both OAuth2Feature.java and TestOAuth2Feature.java.

Having it misspelled in the test has prevented the detection of a problem by the test.

Thanks to Stefan Widmer of Synus Informatik to bring this to our attention.