### PR TITLE
upgrade to dev@v3: use java21+maven3.9+project-build-plugin:11.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,6 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v2
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v3
     secrets:
       mvnArgs: -Dtest.azure.app.id=${{ secrets.AZURE_APP_ID }} -Dtest.azure.app.secretKey=${{ secrets.AZURE_APP_SECRET }} -Dtest.azure.app.tenantId=${{ secrets.AZURE_APP_TENANT_ID }} -Dtest.azure.webtest.username=${{ secrets.AZURE_APP_USER_NAME }} -Dtest.azure.webtest.pass=${{ secrets.AZURE_APP_USER_PASS }} 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,5 +10,5 @@ jobs:
   build:
     uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v2
     secrets:
-      mvnArgs: -Dtester.version=11.2.0-SNAPSHOT -Dtest.azure.app.id=${{ secrets.AZURE_APP_ID }} -Dtest.azure.app.secretKey=${{ secrets.AZURE_APP_SECRET }} -Dtest.azure.app.tenantId=${{ secrets.AZURE_APP_TENANT_ID }} -Dtest.azure.webtest.username=${{ secrets.AZURE_APP_USER_NAME }} -Dtest.azure.webtest.pass=${{ secrets.AZURE_APP_USER_PASS }} 
+      mvnArgs: -Dproject.build.plugin.version=11.4.0-SNAPSHOT -Dtester.version=11.4.0-SNAPSHOT -Dtest.azure.app.id=${{ secrets.AZURE_APP_ID }} -Dtest.azure.app.secretKey=${{ secrets.AZURE_APP_SECRET }} -Dtest.azure.app.tenantId=${{ secrets.AZURE_APP_TENANT_ID }} -Dtest.azure.webtest.username=${{ secrets.AZURE_APP_USER_NAME }} -Dtest.azure.webtest.pass=${{ secrets.AZURE_APP_USER_PASS }} 
     

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v2
+    uses: axonivy-market/github-workflows/.github/workflows/dev.yml@v3
     secrets:
-      mvnArgs: -Dproject.build.plugin.version=11.4.0-SNAPSHOT -Dtester.version=11.4.0-SNAPSHOT -Dtest.azure.app.id=${{ secrets.AZURE_APP_ID }} -Dtest.azure.app.secretKey=${{ secrets.AZURE_APP_SECRET }} -Dtest.azure.app.tenantId=${{ secrets.AZURE_APP_TENANT_ID }} -Dtest.azure.webtest.username=${{ secrets.AZURE_APP_USER_NAME }} -Dtest.azure.webtest.pass=${{ secrets.AZURE_APP_USER_PASS }} 
+      mvnArgs: -Dtest.azure.app.id=${{ secrets.AZURE_APP_ID }} -Dtest.azure.app.secretKey=${{ secrets.AZURE_APP_SECRET }} -Dtest.azure.app.tenantId=${{ secrets.AZURE_APP_TENANT_ID }} -Dtest.azure.webtest.username=${{ secrets.AZURE_APP_USER_NAME }} -Dtest.azure.webtest.pass=${{ secrets.AZURE_APP_USER_PASS }} 
     

--- a/msgraph-calendar-demo/pom.xml
+++ b/msgraph-calendar-demo/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <dependencies>
     <dependency>

--- a/msgraph-calendar-demo/pom.xml
+++ b/msgraph-calendar-demo/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>msgraph-calendar-demo</artifactId>
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.office365</groupId>
@@ -27,7 +30,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/msgraph-connector-test/pom.xml
+++ b/msgraph-connector-test/pom.xml
@@ -7,7 +7,7 @@
   <packaging>iar-integration-test</packaging>
   
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
     <tester.version>10.0.14</tester.version>
   </properties>
   

--- a/msgraph-connector-test/pom.xml
+++ b/msgraph-connector-test/pom.xml
@@ -7,6 +7,7 @@
   <packaging>iar-integration-test</packaging>
   
   <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
     <tester.version>10.0.14</tester.version>
   </properties>
   
@@ -150,7 +151,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/msgraph-connector/pom.xml
+++ b/msgraph-connector/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <dependencies>
     <dependency>

--- a/msgraph-connector/pom.xml
+++ b/msgraph-connector/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>msgraph-connector</artifactId>
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.msgraph</groupId>
@@ -35,7 +38,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/msgraph-mail-demo/pom.xml
+++ b/msgraph-mail-demo/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <dependencies>
     <dependency>

--- a/msgraph-mail-demo/pom.xml
+++ b/msgraph-mail-demo/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>msgraph-mail-demo</artifactId>
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.office365</groupId>
@@ -27,7 +30,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/msgraph-oauth-feature/pom.xml
+++ b/msgraph-oauth-feature/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>msgraph-oauth-feature</artifactId>
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+  </properties>
   <scm>
     <developerConnection>scm:git:https://github.com/axonivy-market/${project.name}.git</developerConnection>
     <tag>HEAD</tag>
@@ -24,7 +27,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>

--- a/msgraph-oauth-feature/pom.xml
+++ b/msgraph-oauth-feature/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <scm>
     <developerConnection>scm:git:https://github.com/axonivy-market/${project.name}.git</developerConnection>

--- a/msgraph-sharepoint-demo/pom.xml
+++ b/msgraph-sharepoint-demo/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <dependencies>
     <dependency>

--- a/msgraph-sharepoint-demo/pom.xml
+++ b/msgraph-sharepoint-demo/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>msgraph-sharepoint-demo</artifactId>
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.office365</groupId>
@@ -18,7 +21,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/msgraph-teams-demo/pom.xml
+++ b/msgraph-teams-demo/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <dependencies>
     <dependency>

--- a/msgraph-teams-demo/pom.xml
+++ b/msgraph-teams-demo/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>msgraph-teams-demo</artifactId>
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.office365</groupId>
@@ -24,7 +27,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/msgraph-teams-notification/pom.xml
+++ b/msgraph-teams-notification/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>msgraph-teams-notification</artifactId>
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.office365</groupId>
@@ -18,7 +21,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/msgraph-teams-notification/pom.xml
+++ b/msgraph-teams-notification/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <dependencies>
     <dependency>

--- a/msgraph-todo-demo/pom.xml
+++ b/msgraph-todo-demo/pom.xml
@@ -5,6 +5,9 @@
   <artifactId>msgraph-todo-demo</artifactId>
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
+  <properties>
+    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+  </properties>
   <dependencies>
     <dependency>
       <groupId>com.axonivy.connector.office365</groupId>
@@ -27,7 +30,7 @@
       <plugin>
         <groupId>com.axonivy.ivy.ci</groupId>
         <artifactId>project-build-plugin</artifactId>
-        <version>10.0.14</version>
+        <version>${project.build.plugin.version}</version>
         <extensions>true</extensions>
       </plugin>
     </plugins>

--- a/msgraph-todo-demo/pom.xml
+++ b/msgraph-todo-demo/pom.xml
@@ -6,7 +6,7 @@
   <version>10.0.7-SNAPSHOT</version>
   <packaging>iar</packaging>
   <properties>
-    <project.build.plugin.version>10.0.14</project.build.plugin.version>
+    <project.build.plugin.version>10.0.16</project.build.plugin.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
roll-out v3 pipelines, complying with 11.4 that uses Maven3.9 and Java21.

more detail onto how this was built and can be taken as receipt can be found here https://github.com/axonivy-market/a-trust-connector/pull/30#issue-2424491715