### PR TITLE
MARP-2702 MS-Graph CI-build cannot scheduled trigger - change cron configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI-Build
 on:
   push:
   schedule:
-    - cron:  '21 21 * * *'
+    - cron: '21 21 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -3,7 +3,7 @@ name: Dev-Build
 on:
   push:
   schedule:
-    - cron:  '21 21 * * *'
+    - cron: '25 21 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Hi @ivy-rew,
When I monitor the market extensions on the page https://market.axonivy.com/monitoring, we noticed that while the Dev-Build is running as scheduled, the CI-Build hasn't triggered automatically yet https://github.com/axonivy-market/msgraph-connector/actions/workflows/ci.yml?query=event%3Aschedule.

To troubleshoot, we are going to stagger the start times to ensure GitHub's scheduler doesn't skip the CI-Build due to a potential concurrency conflict.

However, we aren't certain if this will fully fix the issue yet, but it's a necessary step to see if GitHub's scheduler is dropping the job.

Could you please share your advice on this issue?